### PR TITLE
torch 2.0 compatibility

### DIFF
--- a/sampler.py
+++ b/sampler.py
@@ -123,7 +123,8 @@ def makePytorchData(
     pytorch_data = torch.from_numpy(np_data_rescaled).to(device)
     n_data_points = pytorch_data.data.shape[0]
     data_loader = DataLoader(
-        pytorch_data, batch_size=BATCH_SIZE, shuffle=shuffle
+        pytorch_data, batch_size=BATCH_SIZE, shuffle=shuffle,
+        generator=torch.Generator(device=device)
     )
     return data_loader
 


### PR DESCRIPTION
Difference in docs:

 - https://pytorch.org/docs/1.7.1/data.html#torch.utils.data.DataLoader
 - https://pytorch.org/docs/2.0/data.html#torch.utils.data.DataLoader

I haven't backwards tested this, but it looks like it should work. The error without this line is something about device mismatch.